### PR TITLE
Lower default max gas config for osmosis

### DIFF
--- a/relaying/hermes/config.toml
+++ b/relaying/hermes/config.toml
@@ -115,7 +115,7 @@ rpc_timeout = '15s'
 account_prefix = 'osmo'
 key_name = 'osmosis'
 store_prefix = 'ibc'
-max_gas = 60000000
+max_gas = 10000000
 max_msg_num = 30
 gas_price = { price = 0.000, denom = 'uosmo' }
 gas_adjustment = 1


### PR DESCRIPTION
Today some relayers with misconfigured relayers at 60M gas caused huge problems for the network via chain congestion. This lowers the max gas from 60M to 10M. The current number of max msgs is 30, which 10M gas is currently more than sufficient to handle.